### PR TITLE
2744 add inputs to theme forms

### DIFF
--- a/pages/login/page-login.htm
+++ b/pages/login/page-login.htm
@@ -25,18 +25,19 @@ url: /login
 					{{ open_form({'data-ajax-handler': 'shop:onSignup', 'data-validation-message' : ''}) }}
 						<h3>Register</h3>
 						
-						<input name="signup[first_name]" id="signup[first_name]" type="text" class="md-input col-xs-12" placeholder="First Name" />
+						<input name="signup[first_name]" id="signup[first_name]" type="text" class="md-input col-xs-12" placeholder="First Name *" />
 
-						<input name="signup[last_name]" id="signup[last_name]" type="text" class="md-input col-xs-12"  placeholder="Last Name"/>
+						<input name="signup[last_name]" id="signup[last_name]" type="text" class="md-input col-xs-12"  placeholder="Last Name *"/>
 						
-						<input id="signup[email]" type="text" name="signup[email]" class="md-input col-xs-12"  placeholder="Email"/>
+						<input id="signup[email]" type="text" name="signup[email]" class="md-input col-xs-12"  placeholder="Email *"/>
 						
-						<input name="signup[password]" id="signup[password]" type="password" class="md-input col-xs-12"  placeholder="Password"/>
+						<input name="signup[password]" id="signup[password]" type="password" class="md-input col-xs-12"  placeholder="Password *"/>
 						
-						<input name="signup[password_confirmation]" id="signup[password_confirmation]" type="password" class="md-input col-xs-12"  placeholder="Confirm Password"/>
+						<input name="signup[password_confirmation]" id="signup[password_confirmation]" type="password" class="md-input col-xs-12"  placeholder="Confirm Password *"/><br>
 
 						<input type="hidden" name="autologin" value="1" />
 						<input type="hidden" name="redirect" value="{{ site_url('registered') }}"/>
+						<input class="accepts-marketing" name="accepts_marketing" type="checkbox" id="accepts_marketing" checked/> Recieve promotional emails
           
 						<button class="md-button narrow">submit</button>
 					{{ close_form() }}

--- a/pages/login/page-login.htm
+++ b/pages/login/page-login.htm
@@ -33,12 +33,12 @@ url: /login
 						
 						<input name="signup[password]" id="signup[password]" type="password" class="md-input col-xs-12"  placeholder="Password *"/>
 						
-						<input name="signup[password_confirmation]" id="signup[password_confirmation]" type="password" class="md-input col-xs-12"  placeholder="Confirm Password *"/><br>
+						<input name="signup[password_confirmation]" id="signup[password_confirmation]" type="password" class="md-input col-xs-12"  placeholder="Confirm Password *" style="margin-bottom: 15px"/><br>
+
+						<input class="md-check" name="accepts_marketing" type="checkbox" id="accepts_marketing" checked/> Recieve promotional emails
 
 						<input type="hidden" name="autologin" value="1" />
 						<input type="hidden" name="redirect" value="{{ site_url('registered') }}"/>
-						<input class="accepts-marketing" name="accepts_marketing" type="checkbox" id="accepts_marketing" checked/> Recieve promotional emails
-          
 						<button class="md-button narrow">submit</button>
 					{{ close_form() }}
 				</div>

--- a/partials/shop-checkout-billing-address.htm
+++ b/partials/shop-checkout-billing-address.htm
@@ -73,6 +73,9 @@
 			<div class="col-xs-3 button-holder right">
 				<a class="md-button step-btn" href="javascript:;" id="billing-continue">continue</a>
 			</div>
+			<div class="col-xs-9 checkbox-holder">
+				<input class="accepts-marketing" type="checkbox" checked/> Recieve promotional emails
+			</div>
 		</div>
 		
 		<input type="hidden" id="billing-current-step" name="step" value="billing_info"/>

--- a/partials/shop-checkout-billing-address.htm
+++ b/partials/shop-checkout-billing-address.htm
@@ -74,7 +74,7 @@
 				<a class="md-button step-btn" href="javascript:;" id="billing-continue">continue</a>
 			</div>
 			<div class="col-xs-9 checkbox-holder">
-				<input class="accepts-marketing" name="accepts_marketing" type="checkbox" id="accepts_marketing" checked/> Recieve promotional emails
+				<input class="md-check" name="accepts_marketing" type="checkbox" id="accepts_marketing" checked/> Recieve promotional emails
 			</div>
 		</div>
 		

--- a/partials/shop-checkout-billing-address.htm
+++ b/partials/shop-checkout-billing-address.htm
@@ -74,7 +74,7 @@
 				<a class="md-button step-btn" href="javascript:;" id="billing-continue">continue</a>
 			</div>
 			<div class="col-xs-9 checkbox-holder">
-				<input class="accepts-marketing" type="checkbox" checked/> Recieve promotional emails
+				<input class="accepts-marketing" name="accepts_marketing" type="checkbox" id="accepts_marketing" checked/> Recieve promotional emails
 			</div>
 		</div>
 		

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -2979,6 +2979,34 @@ outline: none;
       border:1px solid #34a994;
     
 }
+.accepts-marketing{
+      vertical-align: middle;
+    display: inline-block;
+background-color: transparent;
+   -webkit-appearance: none;
+    -moz-appearance: none;
+    -o-appearance:none;
+    appearance: none;
+    background-color: #fff;
+    border:1px solid #ddd;
+    width: 17px;
+    outline: none;
+    height: 17px;
+}
+.accepts-marketing:hover{
+cursor: pointer;
+   
+}
+.accepts-marketing:checked,.accepts-marketing.checked{
+ border:1px solid #000;
+background-color: #34a994;
+outline: none;
+}
+.accepts-marketing:checked,.accepts-marketing:focus,.accepts-marketing:hover{
+      outline: none;
+      border:1px solid #34a994;
+    
+}
 .step-btn {
     padding: 7px 23px;
     font-size: 13px;

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -2979,34 +2979,6 @@ outline: none;
       border:1px solid #34a994;
     
 }
-.accepts-marketing{
-      vertical-align: middle;
-    display: inline-block;
-background-color: transparent;
-   -webkit-appearance: none;
-    -moz-appearance: none;
-    -o-appearance:none;
-    appearance: none;
-    background-color: #fff;
-    border:1px solid #ddd;
-    width: 17px;
-    outline: none;
-    height: 17px;
-}
-.accepts-marketing:hover{
-cursor: pointer;
-   
-}
-.accepts-marketing:checked,.accepts-marketing.checked{
- border:1px solid #000;
-background-color: #34a994;
-outline: none;
-}
-.accepts-marketing:checked,.accepts-marketing:focus,.accepts-marketing:hover{
-      outline: none;
-      border:1px solid #34a994;
-    
-}
 .step-btn {
     padding: 7px 23px;
     font-size: 13px;

--- a/resources/js/script.js
+++ b/resources/js/script.js
@@ -163,6 +163,12 @@ $(document).ready(function() {
         });
     }
 
+    if ($('.accepts-marketing').length > 0) {
+    $('.accepts-marketing').iCheck({
+            checkboxClass: 'accepts-marketing'
+        });
+    }
+
     //Featured, Arrival Tab controller
     $('.panel-title > a').click(function(e) {
         e.preventDefault();

--- a/resources/js/script.js
+++ b/resources/js/script.js
@@ -164,7 +164,7 @@ $(document).ready(function() {
     }
 
     if ($('.accepts-marketing').length > 0) {
-    $('.accepts-marketing').iCheck({
+        $('.accepts-marketing').iCheck({
             checkboxClass: 'accepts-marketing'
         });
     }

--- a/resources/js/script.js
+++ b/resources/js/script.js
@@ -163,12 +163,6 @@ $(document).ready(function() {
         });
     }
 
-    if ($('.accepts-marketing').length > 0) {
-        $('.accepts-marketing').iCheck({
-            checkboxClass: 'accepts-marketing'
-        });
-    }
-
     //Featured, Arrival Tab controller
     $('.panel-title > a').click(function(e) {
         e.preventDefault();


### PR DESCRIPTION
Added same css and js as the "same as billing information" checkbox, but didn't add the function that made it skip the shipping address step.

https://github.com/lemonstand/lemonstand-2/issues/2744
