### PR TITLE
Fixed homepage from adding products without options and checkout skip…

### DIFF
--- a/partials/home-featured-products.htm
+++ b/partials/home-featured-products.htm
@@ -1,7 +1,36 @@
 {% if featuredCollection %}
     {% for product in featuredCollection.products %}
         <div class="col-lg-offset-0 col-lg-3 col-sm-4 col-sm-offset-1 col-xs-10 col-xs-offset-2 product-holder">
-            {{ partial('shop-grid-item', { 'product': product }) }}
+            <div class="product-item text-center">
+						{% if product.images.count > 1 %}
+						    <a href="#next" class="mini-next"></a>
+						    <a href="#prev" class="mini-prev"></a>
+						    <div class="image ">
+						        <div class="product-mini-gallery">
+						        {% for image in product.images %}
+						            <img alt="{{ product.name }}" src="{{ image.thumbnail(212, 'auto') }}" width="212" height="281" />
+						        {% endfor %}
+						        </div>
+						    </div>
+						{% else %}
+						    <img src="{{ product.image.thumbnail(212, 'auto') }}" alt="{{ product.name }}" width="212" height="281" />
+						{% endif %}
+
+    <hr>
+
+    <div class="title uppercase bold">
+        <a href="/product/{{ product.url_name }}">{{ product.name }}</a>
+    </div>
+    <div class="price">
+        <span>{{ product.price|currency }}</span>
+    </div>
+    <div class="buttons-holder">
+        <div class="add-cart-holder">
+            <input type="hidden" name="productId" value="{{ product.id }}"/>
+            <a class="md-button" href="/product/{{ product.url_name }}">Select Options</a>
+        </div>
+    </div>
+</div>
         </div>
     {% endfor %}
 {% else %}

--- a/partials/shop-checkout-billing-address.htm
+++ b/partials/shop-checkout-billing-address.htm
@@ -76,11 +76,11 @@
             <div class="col-xs-9 checkbox-holder">
                 <input class="md-check" type="checkbox"> Use this address for shipping
             </div>
-            <div class="col-xs-3 button-holder right">
-                <a class="md-button step-btn" href="javascript:;" id="billing-continue">continue</a>
-            </div>
             <div class="col-xs-9 checkbox-holder">
                 <input class="md-check" name="accepts_marketing" type="checkbox" id="accepts_marketing" checked/> Recieve promotional emails
+            </div>
+            <div class="col-xs-12 button-holder right">
+                <a class="md-button step-btn right" href="#" data-ajax-handler="shop:checkout" data-ajax-update="#checkout-page=shop-checkout, #mini-cart=shop-minicart" data-ajax-extra-fields="nextStep=shipping_info">Continue</a>
             </div>
         </div>
         


### PR DESCRIPTION
Homepage was adding products directly to the cart which made it possible to add them without options. Changed that to "Select Options" which goes to the product page. 

Fixed billing step so that shipping step isn't skipped.